### PR TITLE
Make user in charge compulsory

### DIFF
--- a/netconfig
+++ b/netconfig
@@ -1262,7 +1262,7 @@ def main():
     if bInteractive and bNewNode:
         print "\nAdding a new node (press Ctrl-C to cancel):"
         while strSubnet == None:
-            print "List of available subnets:"
+            print "List of available subnets: and TEST local"
             lstSubnets = list_subnet(ldapDatabase, dnBase)
             for subnet in sorted(lstSubnets):
                 print "\t" + subnet
@@ -1297,6 +1297,9 @@ def main():
                 strMacAddress = None
         while strManager == None:
             strManager = raw_input("User in charge of this node: ")
+            if len(strManager) == 0:
+                strManager = None	
+                print "User in charge of this node required."
         while strConsole == None:
             strConsole = raw_input("Terminal server to which the console is connected (<host>:<port#>, leave blank if unapplicable): ")
         while strPowerOutlet == None:

--- a/netconfig
+++ b/netconfig
@@ -1262,7 +1262,7 @@ def main():
     if bInteractive and bNewNode:
         print "\nAdding a new node (press Ctrl-C to cancel):"
         while strSubnet == None:
-            print "List of available subnets: and TEST local"
+            print "List of available subnets:"
             lstSubnets = list_subnet(ldapDatabase, dnBase)
             for subnet in sorted(lstSubnets):
                 print "\t" + subnet


### PR DESCRIPTION
When adding a new node to netconfig the `user` field is a required, but the interactive script does not require the field. The result of not inputting a user is an error:
```
line 1961, in <module>
    main()
  File "/cds/sw/tools/bin/netconfig", line 1578, in main
    raise RuntimeError("user %s not found in database" % (strManager))
RuntimeError: user  not found in database
```

This PR makes adding a user required similar to PC number:

```
        srv.pcdsn
        swhmgt.pcdsn
        visitor.pcdsn
Subnet: cds-xcs.pcdsn
Name: fasfads
DNS cnames (separated by spaces): 
Non-DNS Aliases (separated by spaces): 
Monit groups (separated by spaces): 
PC# (enter only the numeric number):
Please enter the PC#, 00000 if unavailable now. However please look it up and enter asap.
PC# (enter only the numeric number):
Please enter the PC#, 00000 if unavailable now. However please look it up and enter asap.
PC# (enter only the numeric number):00000
Location:
Please enter the physical location (format should be 'building,room,comment' or 'building,room,rack,elevation'):
Location:113
Node MAC address: 
Invalid MAC address , try again.

Node MAC address: 00:01:05:5b:12:43
User in charge of this node: 
User in charge of this node required.
User in charge of this node: 
User in charge of this node required.
User in charge of this node: 
User in charge of this node required.
User in charge of this node: nrw
```